### PR TITLE
Update YahooCurl.class.php

### DIFF
--- a/lib/Yahoo/YahooCurl.class.php
+++ b/lib/Yahoo/YahooCurl.class.php
@@ -119,7 +119,7 @@ class YahooCurl
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $options['timeout']);
 
     // be nice to dev ssl certs
-    curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, true);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
     curl_setopt($ch, CURLOPT_FAILONERROR, false);
 


### PR DESCRIPTION
 curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, true);

This should be numeric. True=1, which I believe, is disabled. I see your comment that this is to be nice to "dev certs", but this is wrong either way. Additionally, this practice is very dangerous, just ask Apple about their iOS bug.
